### PR TITLE
fix: refresh ads on pathname change #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Give me a ⭐ if you like it.
 - Support SSR (Server-Side Rendering), SSG (Static Site Generation) and CSR (Client-Side Rendering)
 - Support TypeScript
 - Zero Dependencies
+- Dummy Ad Support for Development - Preview ads locally without real AdSense integration
 - Theoretically support all AdSense AD types (see [🎨 Create a custom layout](#-create-a-custom-layout) for more details)
 - Create `ads.txt` automatically (see [Initialization / Verification](#initialization--verification-) for more details)
 
@@ -28,10 +29,14 @@ Give me a ⭐ if you like it.
   - [Usage](#usage-)
     - [Auto Ads](#auto-ads)
     - [Manual Ads](#manual-ads)
+    - [Dummy Ads for Development](#dummy-ads-for-development-)
 - [📖 API Reference](#-api-reference)
   - [Components](#components)
     - [GoogleAdSense](#initializes-the-google-adsense)
     - [AdUnit](#manual-ad)
+  - [Ad Sizes](#ad-sizes)
+    - [Display Ad Sizes](#display-ad-sizes)
+    - [In-Article Ad Sizes](#in-article-ad-sizes)
 - [🎨 Create a custom layout](#-create-a-custom-layout)
   - [How to convert the given html to a custom layout?](#how-to-convert-the-given-html-to-a-custom-layout)
 - [🐛 Known Issues](#-known-issues)
@@ -125,6 +130,9 @@ If you decide to use Auto Ads, you are good to go. The ads will be automatically
 
 #### Manual Ads
 
+> [!NOTE]\
+> Google AdSense does't work in local environment. You need to test it in production or use [Dummy Ads for Development](#dummy-ads-for-development-).
+
 ```typescript
 import { AdUnit } from "next-google-adsense";
 
@@ -150,6 +158,54 @@ const Page = () => {
 export default Page;
 ```
 
+#### Dummy Ads for Development 🧪
+
+Perfect for development and testing! Show realistic ad placeholders without needing actual AdSense approval.
+
+```typescript
+import { AdUnit, DISPLAY_AD_SIZES, ARTICLE_AD_SIZES } from "next-google-adsense";
+
+const Page = () => {
+  return (
+    <>
+      {/* Using predefined sizes */}
+      <AdUnit
+        slotId="1234567890"
+        layout="display"
+        dummySize="LEADERBOARD"  {/* 728x90 */}
+      />
+
+      <AdUnit
+        slotId="1234567890"
+        layout="in-article"
+        dummySize="MEDIUM_RECTANGLE"  {/* 300x250 */}
+      />
+
+      {/* Using custom dimensions */}
+      <AdUnit
+        slotId="1234567890"
+        layout="display"
+        dummySize={{ width: 600, height: 400 }}
+      />
+
+      {/* Using size objects directly */}
+      <AdUnit
+        slotId="1234567890"
+        layout="display"
+        dummySize={DISPLAY_AD_SIZES.BANNER}  {/* 468x60 */}
+      />
+
+      <YourContent />
+    </>
+  );
+};
+
+export default Page;
+```
+
+> [!NOTE]\
+> Dummy ads only appear when the `dummySize` prop is provided. In production (when `NODE_ENV`/`NEXT_PUBLIC_ENV` is not "development"), real ads will be displayed instead.
+
 ## 📖 API Reference
 
 ### Components
@@ -167,15 +223,65 @@ export default Page;
 #### Manual AD
 
 ```typescript
-<AdUnit publisherId={string} slotId={string} layout={"display" | "in-article" | "custom"} customLayout={JSX.Element}>
+<AdUnit publisherId={string} slotId={string} layout={"display" | "in-article" | "custom"} customLayout={JSX.Element} dummySize={DisplayAdSize | ArticleAdSize | {width: number, height: number}}>
 ```
 
-| Parameter    | Optional | Type                                  | Default   | Description                                                                                         |
-| ------------ | -------- | ------------------------------------- | --------- | --------------------------------------------------------------------------------------------------- |
-| publisherId  | Yes      | string                                | n/a       | You can skip this parameter if you set the environment variable `NEXT_PUBLIC_ADSENSE_PUBLISHER_ID`. |
-| slotId       | No       | string                                | n/a       | Google AdSense Slot ID.                                                                             |
-| layout       | Yes      | "display" \| "in-article" \| "custom" | "display" | The layout of the AD.                                                                               |
-| customLayout | Yes      | JSX.Element                           | n/a       | The custom layout of the AD. This parameter is required if `layout` is set to "custom".             |
+| Parameter    | Optional | Type                                                                        | Default   | Description                                                                                         |
+| ------------ | -------- | --------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------- |
+| publisherId  | Yes      | string                                                                      | n/a       | You can skip this parameter if you set the environment variable `NEXT_PUBLIC_ADSENSE_PUBLISHER_ID`. |
+| slotId       | No       | string                                                                      | n/a       | Google AdSense Slot ID.                                                                             |
+| layout       | Yes      | "display" \| "in-article" \| "custom"                                       | "display" | The layout of the AD.                                                                               |
+| customLayout | Yes      | JSX.Element                                                                                                       | n/a       | The custom layout of the AD. This parameter is required if `layout` is set to "custom".             |
+| dummySize    | Yes      | DisplayAdSize \| ArticleAdSize \| {width: number, height: number}          | n/a       | Show dummy ad for development. Only appears when this prop is provided.                             |
+
+### Dummy Ad Sizes
+
+All available ad sizes for the `dummySize` prop:
+
+#### Display Ad Sizes
+
+For `layout="display"` ads:
+
+| Size Name            | Key                    | Dimensions  | Best For                    |
+| -------------------- | ---------------------- | ----------- | --------------------------- |
+| Leaderboard          | `"LEADERBOARD"`        | 728 × 90    | Top of page, headers        |
+| Banner               | `"BANNER"`             | 468 × 60    | Above content               |
+| Half Banner          | `"HALF_BANNER"`        | 234 × 60    | Small horizontal spaces     |
+| Medium Rectangle     | `"MEDIUM_RECTANGLE"`   | 300 × 250   | Within content, sidebars    |
+| Large Rectangle      | `"LARGE_RECTANGLE"`    | 336 × 280   | Above the fold              |
+| Vertical Banner      | `"VERTICAL_BANNER"`    | 120 × 240   | Narrow sidebars             |
+| Wide Skyscraper      | `"WIDE_SKYSCRAPER"`    | 160 × 600   | Wide sidebars               |
+| Skyscraper           | `"SKYSCRAPER"`         | 120 × 600   | Narrow sidebars             |
+| Mobile Banner        | `"MOBILE_BANNER"`      | 320 × 50    | Mobile devices              |
+| Large Mobile Banner  | `"LARGE_MOBILE_BANNER"` | 320 × 100   | Mobile devices, larger      |
+
+#### In-Article Ad Sizes
+
+For `layout="in-article"` ads:
+
+| Size Name        | Key                  | Dimensions | Best For                     |
+| ---------------- | -------------------- | ---------- | ---------------------------- |
+| Small Square     | `"SMALL_SQUARE"`     | 200 × 200  | Small content breaks         |
+| Square           | `"SQUARE"`           | 250 × 250  | Content breaks               |
+| Medium Rectangle | `"MEDIUM_RECTANGLE"` | 300 × 250  | Between paragraphs           |
+| Large Rectangle  | `"LARGE_RECTANGLE"`  | 336 × 280  | Longer content breaks        |
+
+#### Usage Examples
+
+```typescript
+import { AdUnit, DISPLAY_AD_SIZES, ARTICLE_AD_SIZES } from "next-google-adsense";
+
+// Using predefined size keys
+<AdUnit slotId="123" layout="display" dummySize="LEADERBOARD" />
+<AdUnit slotId="456" layout="in-article" dummySize="SQUARE" />
+
+// Using size objects
+<AdUnit slotId="789" layout="display" dummySize={DISPLAY_AD_SIZES.BANNER} />
+<AdUnit slotId="101" layout="in-article" dummySize={ARTICLE_AD_SIZES.MEDIUM_RECTANGLE} />
+
+// Using custom dimensions
+<AdUnit slotId="112" layout="display" dummySize={{ width: 400, height: 300 }} />
+```
 
 ## 🎨 Create a custom layout
 
@@ -198,7 +304,7 @@ export const InFeedAd = () => {
 };
 ```
 
-#### How to convert the given html to a custom layout?
+### How to convert the given html to a custom layout?
 
 Example (provided by Google AdSense):
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Give me a ⭐ if you like it.
 | Support Matched Content Ad | ✅                         | ❌                                                                     |
 | Dynamic `ads.txt`          | ✅                         | ❌                                                                     |
 | Multiple ADs on one page   | ✅                         | ⚠️\*1                                                                  |
+| Dummy Ad for Development   | ✅                         | ❌                                                                     |
 
 \*1: According to the their [documentation](https://github.com/btk/nextjs-google-adsense/blob/master/README.md) seems it is ok to use multiple ADs on one page. But I found that it will cause an error.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "next-google-adsense",
-  "version": "1.0.13",
+  "version": "1.0.15-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-google-adsense",
-      "version": "1.0.13",
+      "version": "1.0.15-beta.1",
       "license": "MIT",
+      "dependencies": {
+        "assert-never": "^1.4.0"
+      },
       "bin": {
         "create-ads-txt": "bin/cli.mjs"
       },
@@ -2404,6 +2407,11 @@
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true
+    },
+    "node_modules/assert-never": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.4.0.tgz",
+      "integrity": "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA=="
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-google-adsense",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-google-adsense",
-      "version": "1.1.0-beta.1",
+      "version": "1.1.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "assert-never": "^1.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-google-adsense",
-  "version": "1.0.15-beta.1",
+  "version": "1.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-google-adsense",
-      "version": "1.0.15-beta.1",
+      "version": "1.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "assert-never": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-google-adsense",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "description": "Next.js Google AdSense",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-google-adsense",
-  "version": "1.0.14",
+  "version": "1.0.15-beta.1",
   "description": "Next.js Google AdSense",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "pub": "npm run test && npm run build && npm publish",
     "lint": "biome check",
     "fmt": "biome format",
+    "fmt:fix": "biome format --write",
     "pub@beta": "npm run test && npm run build && npm publish --tag beta",
     "semantic-release": "semantic-release"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-google-adsense",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "description": "Next.js Google AdSense",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
   },
   "bin": {
     "create-ads-txt": "./bin/cli.mjs"
+  },
+  "dependencies": {
+    "assert-never": "^1.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-google-adsense",
-  "version": "1.0.15-beta.1",
+  "version": "1.1.0-beta.1",
   "description": "Next.js Google AdSense",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      assert-never:
+        specifier: ^1.4.0
+        version: 1.4.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.2.4
@@ -577,6 +581,9 @@ packages:
 
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
+  assert-never@1.4.0:
+    resolution: {integrity: sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -2217,6 +2224,8 @@ snapshots:
   argv-formatter@1.0.0: {}
 
   array-ify@1.0.0: {}
+
+  assert-never@1.4.0: {}
 
   assertion-error@2.0.1: {}
 

--- a/src/AdLayout.tsx
+++ b/src/AdLayout.tsx
@@ -28,7 +28,7 @@ export const Display = ({
   ...props
 }: DisplayProps) => {
   if (dummySize && isDevelopment()) {
-    return <DummyAd size={dummySize} {...props} />;
+    return <DummyAd label="Display Ad" size={dummySize} {...props} />;
   }
 
   return (
@@ -53,7 +53,7 @@ export const InArticle = ({
   ...props
 }: InArticleProps) => {
   if (dummySize && isDevelopment()) {
-    return <DummyAd size={dummySize} {...props} />;
+    return <DummyAd label="In-Article Ad" size={dummySize} {...props} />;
   }
 
   return (

--- a/src/AdLayout.tsx
+++ b/src/AdLayout.tsx
@@ -1,6 +1,8 @@
 import type { DetailedHTMLProps } from "react";
 // biome-ignore lint/style/useImportType: needed in the <ins> tag
 import React from "react";
+import { DummyAd } from "./DummyAd";
+import { isDevelopment } from "./utils";
 
 export type Layout = "display" | "in-article" | "custom";
 
@@ -11,6 +13,7 @@ interface AdLayoutProps
   > {
   dataAdClient: string;
   dataAdSlot: string;
+  dummySize?: { width: number; height: number };
 }
 
 interface DisplayProps extends AdLayoutProps {
@@ -21,8 +24,13 @@ export const Display = ({
   responsive,
   dataAdClient,
   dataAdSlot,
+  dummySize,
   ...props
 }: DisplayProps) => {
+  if (dummySize && isDevelopment()) {
+    return <DummyAd size={dummySize} {...props} />;
+  }
+
   return (
     <ins
       className="adsbygoogle"
@@ -41,8 +49,13 @@ interface InArticleProps extends AdLayoutProps {}
 export const InArticle = ({
   dataAdClient,
   dataAdSlot,
+  dummySize,
   ...props
 }: InArticleProps) => {
+  if (dummySize && isDevelopment()) {
+    return <DummyAd size={dummySize} {...props} />;
+  }
+
   return (
     <ins
       className="adsbygoogle"

--- a/src/AdUnit.tsx
+++ b/src/AdUnit.tsx
@@ -36,11 +36,12 @@ export const AdUnit = ({
 }: AdUnitProps): JSX.Element | null => {
   const pathname = usePathname();
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Refresh ads when pathname changes
   useEffect(() => {
     // biome-ignore lint/suspicious/noAssignInExpressions: adsbygoogle needed
     // biome-ignore lint/suspicious/noExplicitAny: needed to cast to any in order to access adsbygoogle
     ((window as any).adsbygoogle = (window as any).adsbygoogle || []).push({});
-  }, []);
+  }, [pathname]);
 
   const _publisherId =
     process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID ?? publisherId;

--- a/src/DummyAd.tsx
+++ b/src/DummyAd.tsx
@@ -1,0 +1,59 @@
+// biome-ignore lint/correctness/noUnusedImports: React refers to a UMD global, but the current file is a module.
+import React, { type CSSProperties } from "react";
+
+interface DummyAdProps {
+  size: { width: number; height: number };
+  responsive?: boolean;
+  style?: CSSProperties;
+  className?: string;
+  label?: string;
+}
+
+/**
+ * A simple dummy ad component for development purposes
+ * Only renders when dummyAdSize is explicitly provided
+ */
+export const DummyAd = ({
+  size: { width, height },
+  responsive = false,
+  style = {},
+  className = "",
+  label = "Advertisement",
+}: DummyAdProps): JSX.Element => {
+  const containerStyle: CSSProperties = {
+    backgroundColor: "#f5f5f5",
+    border: "2px dashed #ccc",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontFamily: "Arial, sans-serif",
+    fontSize: "14px",
+    color: "#666",
+    textAlign: "center",
+    boxSizing: "border-box",
+    position: "relative",
+    minHeight: responsive ? "50px" : `${height}px`,
+    ...style,
+  };
+
+  if (responsive) {
+    containerStyle.width = "100%";
+    containerStyle.maxWidth = `${width}px`;
+    containerStyle.aspectRatio = `${width} / ${height}`;
+  } else {
+    containerStyle.width = `${width}px`;
+    containerStyle.height = `${height}px`;
+  }
+
+  return (
+    <div className={`dummy-ad ${className}`} style={containerStyle}>
+      <div>
+        <div style={{ fontWeight: "bold", marginBottom: "4px" }}>{label}</div>
+        <div style={{ fontSize: "12px", opacity: 0.7 }}>
+          {width} × {height}
+          {responsive && " (Responsive)"}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,16 +1,52 @@
 const PUBLISHER_ID_REGEX = /^pub-\d{16}$/;
 const SLOT_ID_REGEX = /^\d{10}$/;
 
-export function isPublisherId(id: string | undefined): boolean {
+export const isPublisherId = (id: string | undefined): boolean => {
   if (typeof id !== "string") {
     return false;
   }
   return PUBLISHER_ID_REGEX.test(id);
-}
+};
 
-export function isSlotId(id: string | undefined): boolean {
+export const isSlotId = (id: string | undefined): boolean => {
   if (typeof id !== "string") {
     return false;
   }
   return SLOT_ID_REGEX.test(id);
-}
+};
+
+export const isDevelopment = (): boolean => {
+  return (
+    process.env.NODE_ENV === "development" ||
+    process.env.NEXT_PUBLIC_ENV === "development"
+  );
+};
+
+/**
+ * Common Google AdSense ad sizes for display ads
+ */
+export const DISPLAY_AD_SIZES = {
+  LEADERBOARD: { width: 728, height: 90 },
+  BANNER: { width: 468, height: 60 },
+  HALF_BANNER: { width: 234, height: 60 },
+  MEDIUM_RECTANGLE: { width: 300, height: 250 },
+  LARGE_RECTANGLE: { width: 336, height: 280 },
+  VERTICAL_BANNER: { width: 120, height: 240 },
+  WIDE_SKYSCRAPER: { width: 160, height: 600 },
+  SKYSCRAPER: { width: 120, height: 600 },
+  MOBILE_BANNER: { width: 320, height: 50 },
+  LARGE_MOBILE_BANNER: { width: 320, height: 100 },
+} as const;
+
+/**
+ * Common Google AdSense ad sizes for in-article ads
+ */
+export const ARTICLE_AD_SIZES = {
+  SMALL_SQUARE: { width: 200, height: 200 },
+  SQUARE: { width: 250, height: 250 },
+  MEDIUM_RECTANGLE: { width: 300, height: 250 },
+  LARGE_RECTANGLE: { width: 336, height: 280 },
+} as const;
+
+export type DisplayAdSize = keyof typeof DISPLAY_AD_SIZES;
+export type ArticleAdSize = keyof typeof ARTICLE_AD_SIZES;


### PR DESCRIPTION
## Summary by Sourcery

Refresh AdUnit on route changes by adding pathname to the effect dependency and bump package version to 1.0.15-beta.1

Bug Fixes:
- Refresh ads when pathname changes by including pathname in the useEffect dependency array

Build:
- Bump package version to 1.0.15-beta.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Development-only dummy ad placeholders with a new dummySize prop and responsive behavior.
  - Ad unit now supports multiple layouts including a customizable layout option.

- **Bug Fixes**
  - Ad units refresh on in-app navigation to avoid stale or blank ads.

- **Documentation**
  - README updated with dummy ad usage, size tables, and examples.

- **Chores**
  - Version bumped to 1.1.0-beta.3; added formatting script and a small dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->