### PR TITLE
feat: add isAutoAd prop to GoogleAdSense for better script loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ There are two ways to verify your site (of course you can implement both):
    const App = ({ Component, pageProps }) => {
      return (
        <>
-         <GoogleAdSense publisherId="pub-XXXXXXXXXXXXXXXX" /> {/* 👈 16 digits */}
+         <GoogleAdSense 
+            publisherId="pub-XXXXXXXXXXXXXXXX" // 👈 16 digits
+            isAutoAd={false} // 👈 true if you want to use Auto Ads
+          />
          {/* or */}
          <GoogleAdSense /> {/* if NEXT_PUBLIC_ADSENSE_PUBLISHER_ID is set */}
          <Component {...pageProps} />
@@ -220,6 +223,8 @@ export default Page;
 | Parameter   | Optional | Type   | Default | Description                                                                                         |
 | ----------- | -------- | ------ | ------- | --------------------------------------------------------------------------------------------------- |
 | publisherId | Yes      | string | n/a     | You can skip this parameter if you set the environment variable `NEXT_PUBLIC_ADSENSE_PUBLISHER_ID`. |
+| isAutoAd    | Yes      | boolean| false   | Whether to enable Auto Ads.                                                                         |
+| debug       | Yes      | boolean| false   | Enable Google AdSense debug mode.                                                                   |
 
 #### Manual AD
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-google-adsense",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-google-adsense",
-      "version": "1.1.0-beta.2",
+      "version": "1.1.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "assert-never": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-google-adsense",
-  "version": "1.1.1-beta.3",
+  "version": "1.1.1-beta.4",
   "description": "Next.js Google AdSense",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-google-adsense",
-  "version": "1.1.1-beta.1",
+  "version": "1.1.1-beta.2",
   "description": "Next.js Google AdSense",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-google-adsense",
-  "version": "1.1.1-beta.2",
+  "version": "1.1.1-beta.3",
   "description": "Next.js Google AdSense",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-google-adsense",
-  "version": "1.1.0",
+  "version": "1.1.1-beta.1",
   "description": "Next.js Google AdSense",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-google-adsense",
-  "version": "1.1.1-beta.4",
+  "version": "1.2.0-beta.1",
   "description": "Next.js Google AdSense",
   "main": "dist/index.js",
   "type": "commonjs",

--- a/src/GoogleAdSense.tsx
+++ b/src/GoogleAdSense.tsx
@@ -9,15 +9,18 @@ import { isPublisherId } from "./utils";
 
 interface GoogleAdSenseProps extends Omit<ScriptProps, "src" | "id"> {
   publisherId?: string;
+  isAutoAd?: boolean;
   debug?: boolean;
 }
 
 /**
  * @param publisherId - Google AdSense publisher ID, if not provided, it will use NEXT_PUBLIC_ADSENSE_PUBLISHER_ID from .env
+ * @param isAutoAd - Whether to enable Auto Ads
  * @param debug - Google AdSense debug mode
  */
 export const GoogleAdSense = ({
   publisherId,
+  isAutoAd = false,
   debug = false,
   ...props
 }: GoogleAdSenseProps): JSX.Element | null => {
@@ -37,7 +40,7 @@ export const GoogleAdSense = ({
       src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-${_publisherId}${
         debug ? "google_console=1" : ""
       }`}
-      strategy="lazyOnload"
+      strategy={isAutoAd ? "lazyOnload" : "afterInteractive"}
       crossOrigin="anonymous"
       {...props}
     />

--- a/src/GoogleAdSense.tsx
+++ b/src/GoogleAdSense.tsx
@@ -1,12 +1,10 @@
-"use client";
-
 // ref: https://github.com/btk/nextjs-google-adsense/blob/master/src/components/GoogleAdSense.tsx
 // ref: https://medium.com/frontendweb/how-to-add-google-adsense-in-your-nextjs-89e439f74de3
 
-import { usePathname } from "next/navigation";
 import type { ScriptProps } from "next/script";
+import Script from "next/script";
 // biome-ignore lint/correctness/noUnusedImports: React refers to a UMD global, but the current file is a module.
-import React, { useEffect } from "react";
+import React from "react";
 import { isPublisherId } from "./utils";
 
 interface GoogleAdSenseProps extends Omit<ScriptProps, "src" | "id"> {
@@ -23,36 +21,25 @@ export const GoogleAdSense = ({
   debug = false,
   ...props
 }: GoogleAdSenseProps): JSX.Element | null => {
-  const pathname = usePathname();
   const _publisherId =
     process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID ?? publisherId;
 
-  useEffect(() => {
-    if (!isPublisherId(_publisherId)) {
-      console.error(
-        "❌ [next-google-adsense] Invalid publisherId. It should be like this: pub-xxxxxxxxxxxxxxxx, there is a total of 16 digits behind pub-",
-      );
-      return;
-    }
-
-    // Remove any previous instance
-    const existing = document.querySelector(
-      'script[src*="pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"]',
+  if (!isPublisherId(_publisherId)) {
+    console.error(
+      "❌ [next-google-adsense] Invalid publisherId. It should be like this: pub-xxxxxxxxxxxxxxxx, there is a total of 16 digits behind pub-",
     );
-    if (existing) {
-      existing.remove();
-    }
+    return null;
+  }
 
-    // Delay a frame to make sure the DOM is fully updated
-    requestAnimationFrame(() => {
-      // Insert the Google AdSense script
-      const script = document.createElement("script");
-      script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-${_publisherId}`;
-      script.async = true;
-      script.crossOrigin = "anonymous";
-      document.head.appendChild(script);
-    });
-  }, [pathname, _publisherId]);
-
-  return null;
+  return (
+    <Script
+      async={true}
+      src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-${_publisherId}${
+        debug ? "google_console=1" : ""
+      }`}
+      strategy="lazyOnload"
+      crossOrigin="anonymous"
+      {...props}
+    />
+  );
 };

--- a/src/GoogleAdSense.tsx
+++ b/src/GoogleAdSense.tsx
@@ -5,7 +5,6 @@
 
 import { usePathname } from "next/navigation";
 import type { ScriptProps } from "next/script";
-import Script from "next/script";
 // biome-ignore lint/correctness/noUnusedImports: React refers to a UMD global, but the current file is a module.
 import React, { useEffect } from "react";
 import { isPublisherId } from "./utils";
@@ -46,8 +45,7 @@ export const GoogleAdSense = ({
 
     // Re-insert the script
     const script = document.createElement("script");
-    script.src =
-      "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXX";
+    script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-${_publisherId}`;
     script.async = true;
     script.crossOrigin = "anonymous";
     document.head.appendChild(script);

--- a/src/GoogleAdSense.tsx
+++ b/src/GoogleAdSense.tsx
@@ -1,6 +1,7 @@
 // ref: https://github.com/btk/nextjs-google-adsense/blob/master/src/components/GoogleAdSense.tsx
 // ref: https://medium.com/frontendweb/how-to-add-google-adsense-in-your-nextjs-89e439f74de3
 
+import { usePathname } from "next/navigation";
 import type { ScriptProps } from "next/script";
 import Script from "next/script";
 // biome-ignore lint/correctness/noUnusedImports: React refers to a UMD global, but the current file is a module.
@@ -21,6 +22,7 @@ export const GoogleAdSense = ({
   debug = false,
   ...props
 }: GoogleAdSenseProps): JSX.Element | null => {
+  const pathname = usePathname();
   const _publisherId =
     process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID ?? publisherId;
 
@@ -33,6 +35,8 @@ export const GoogleAdSense = ({
 
   return (
     <Script
+      // Rerender the script when pathname changes to ensure load when navigating pages
+      key={`adsbygoogle-js-${_publisherId}-${pathname}`}
       async={true}
       src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-${_publisherId}${
         debug ? "google_console=1" : ""

--- a/src/GoogleAdSense.tsx
+++ b/src/GoogleAdSense.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // ref: https://github.com/btk/nextjs-google-adsense/blob/master/src/components/GoogleAdSense.tsx
 // ref: https://medium.com/frontendweb/how-to-add-google-adsense-in-your-nextjs-89e439f74de3
 
@@ -5,7 +7,7 @@ import { usePathname } from "next/navigation";
 import type { ScriptProps } from "next/script";
 import Script from "next/script";
 // biome-ignore lint/correctness/noUnusedImports: React refers to a UMD global, but the current file is a module.
-import React from "react";
+import React, { useEffect } from "react";
 import { isPublisherId } from "./utils";
 
 interface GoogleAdSenseProps extends Omit<ScriptProps, "src" | "id"> {
@@ -26,24 +28,30 @@ export const GoogleAdSense = ({
   const _publisherId =
     process.env.NEXT_PUBLIC_ADSENSE_PUBLISHER_ID ?? publisherId;
 
-  if (!isPublisherId(_publisherId)) {
-    console.error(
-      "❌ [next-google-adsense] Invalid publisherId. It should be like this: pub-xxxxxxxxxxxxxxxx, there is a total of 16 digits behind pub-",
-    );
-    return null;
-  }
+  useEffect(() => {
+    if (!isPublisherId(_publisherId)) {
+      console.error(
+        "❌ [next-google-adsense] Invalid publisherId. It should be like this: pub-xxxxxxxxxxxxxxxx, there is a total of 16 digits behind pub-",
+      );
+      return;
+    }
 
-  return (
-    <Script
-      // Rerender the script when pathname changes to ensure load when navigating pages
-      key={`adsbygoogle-js-${_publisherId}-${pathname}`}
-      async={true}
-      src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-${_publisherId}${
-        debug ? "google_console=1" : ""
-      }`}
-      strategy="afterInteractive"
-      crossOrigin="anonymous"
-      {...props}
-    />
-  );
+    // Remove any previous instance
+    const existing = document.querySelector(
+      'script[src*="pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"]',
+    );
+    if (existing) {
+      existing.remove();
+    }
+
+    // Re-insert the script
+    const script = document.createElement("script");
+    script.src =
+      "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXX";
+    script.async = true;
+    script.crossOrigin = "anonymous";
+    document.head.appendChild(script);
+  }, [pathname, _publisherId]);
+
+  return null;
 };

--- a/src/GoogleAdSense.tsx
+++ b/src/GoogleAdSense.tsx
@@ -43,12 +43,15 @@ export const GoogleAdSense = ({
       existing.remove();
     }
 
-    // Re-insert the script
-    const script = document.createElement("script");
-    script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-${_publisherId}`;
-    script.async = true;
-    script.crossOrigin = "anonymous";
-    document.head.appendChild(script);
+    // Delay a frame to make sure the DOM is fully updated
+    requestAnimationFrame(() => {
+      // Insert the Google AdSense script
+      const script = document.createElement("script");
+      script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-${_publisherId}`;
+      script.async = true;
+      script.crossOrigin = "anonymous";
+      document.head.appendChild(script);
+    });
   }, [pathname, _publisherId]);
 
   return null;


### PR DESCRIPTION
## Summary by Sourcery

Introduce isAutoAd flag to toggle script loading strategy for Auto Ads, enhance documentation, and bump the package version.

New Features:
- Add isAutoAd prop to GoogleAdSense to support Auto Ads with lazyOnload script strategy

Enhancements:
- Bump package version to 1.2.0-beta.1

Documentation:
- Update README to document isAutoAd and debug props and update usage examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GoogleAdSense now supports Auto Ads via a new isAutoAd option (default off).
  * Added a debug option to enable debug mode (default off).
  * Optimized script loading behavior when Auto Ads are enabled.

* **Documentation**
  * Updated README with usage examples and API reference for the new options.

* **Chores**
  * Version bumped to 1.2.0-beta.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->